### PR TITLE
#36 Feat: add second_preference sorting and name sorting

### DIFF
--- a/kahlua_admin/serializers/application_serializers.py
+++ b/kahlua_admin/serializers/application_serializers.py
@@ -6,16 +6,4 @@ class ApplyFormListSerializer(serializers.ModelSerializer):
     class Meta:
         model = ApplyForm
         ordering = ['-id']  # 최신순으로 정렬
-        fields = [ # 'name', 'phone_num', 'birthdate', 'first_preference', 'second_preference'만 가져오기
-            'name', 
-            'phone_num', 
-            'birthdate', 
-            'first_preference', 
-            'second_preference',
-        ]
-
-class ApplyFormDetailSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = ApplyForm
-        ordering = ['-id']  # 최신순으로 정렬
         fields = '__all__' # 모두 다 가지고 오기

--- a/kahlua_admin/urls.py
+++ b/kahlua_admin/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
 from .views.tickets_views import FreshmanViewSet, GeneralTicketListViewSet
+from .views.application_views import ApplicationViewSet
 
 app_name = 'kahlua_admin'
 
 urlpatterns = [
     path('tickets/freshman_tickets/', FreshmanViewSet.as_view({'get':'list'}), name='freshman_list'),
     path('tickets/general_tickets/', GeneralTicketListViewSet.as_view({'get':'list'}), name='general_list'),
+    path('application/apply_forms/', ApplicationViewSet.as_view({'get':'list'}), name='applyforms_list'),    
 ]

--- a/kahlua_admin/views/application_views.py
+++ b/kahlua_admin/views/application_views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import get_object_or_404
+from django.db.models import Q
 
 from rest_framework import viewsets, status
 from rest_framework.permissions import IsAuthenticated
@@ -10,27 +11,26 @@ from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 
 from application.models import ApplyForm  # "application"은 지원서를 만드는 모델이 있는 앱 이름입니다.
-from ..serializers.application_serializers import ApplyFormListSerializer, ApplyFormDetailSerializer
+from ..serializers.application_serializers import ApplyFormListSerializer
 
 class ApplicationsPagination(PageNumberPagination):
     page_size = 15
     page_size_query_param = 'page_size'
 
-# 지원한 애들 정보 관리자페이지에서 볼 수 있게
-class ApplicationRetrieveView(viewsets.ModelViewSet):
-    """
-        지원서에서 name, phone_num, birthdate, first_preference, second_preference만 리스트로 가져오기
-    """
-    queryset = ApplyForm.objects.all().order_by('id')
-    serializer_class = ApplyFormListSerializer # ApplyFormListSerializer(위 속성만)에서 가져옴
+# 지원서 어드민 페이지에서 볼 수 있게
+class ApplicationViewSet(viewsets.ModelViewSet):
+    queryset = ApplyForm.objects.all().order_by('-id') # 최근에 지원한 순으로 정렬
+    serializer_class = ApplyFormListSerializer
     permission_classes = [IsAuthenticated]
     pagination_class = ApplicationsPagination
     
     @swagger_auto_schema(
-        operation_id='지원서 리스트 가져오기',
+        operation_id='지원서 리스트 전체 또는 세션별로 가져오기',
         operation_description='''
-            지원서 작성 후 지원서 정보를 조회할 화면을 표시할 때 사용됩니다.<br/>
-            주문 번호에 해당하는 지원서 화면을 보여줍니다.<br/>
+            모든 지원서 또는 세션별 지원서를 리스트로 불러옵니다.<br/>
+            기본 정렬은 최신이 가장 위로 올라오고 모든 지원서가 보이도록 정렬됩니다.<br/>
+            query params에서 name을 True로 설정하면 이름 순으로 정렬됩니다.<br/>
+            query params에서 first_preference를 보컬, 드럼, 베이스, 신디, 기타 등으로 설정하면 해당 세션을 1지망으로 선택한 지원서들이 정렬됩니다.<br/>
         ''',
         responses={
             "200": openapi.Response(
@@ -38,13 +38,20 @@ class ApplicationRetrieveView(viewsets.ModelViewSet):
                 examples={
                     "application/json": {
                         "status": "success",
-                        "data": {'id': 1,
-                                 'name':'깔루아1',
-                                 'phone_num':'010-6337-5958',
-                                 'birthdate':'2002-05-31',
-                                 'first_preference': '기타',
-                                 'second_preference': '신디',
-                                }
+                        "data": {
+                            "id": 1,
+                            "created": "2024-01-10T12:32:09.198136Z",
+                            "updated": "2024-01-10T12:32:09.198178Z",
+                            "name": "kahlua",
+                            "phone_num": "01012345678",
+                            "birthdate": "20050101",
+                            "gender": "남성",
+                            "address": "서울 마포구",
+                            "first_preference": "보컬",
+                            "second_preference": "드럼",
+                            "play_instrument": "통기타",
+                            "motive": "깔루아 들어가고 싶습니다!",
+                        },
                     }
                 }
             ),
@@ -55,68 +62,34 @@ class ApplicationRetrieveView(viewsets.ModelViewSet):
     )
 
     def list(self, request, *args, **kwargs):
-        response = super().list(request, *args, **kwargs)
+        order = self.get_queryset()
+
+        order_name = request.GET.get('name', False)
+        first_preference = request.GET.get('first_preference', False)
+
+        if first_preference: # 1지망을 선택할 때
+            # 1지망이나 2지망이 first_preference인 것들을 받음
+            order = order.filter(Q(first_preference=first_preference) | Q(second_preference=first_preference))
+            if order_name: # 이름순도 선택할 때
+                # 1지망 먼저 나오게, 이름순 정렬
+                first_preference_order = sorted(order, key=lambda x: (x.first_preference == first_preference, x.name))
+                # 그 뒤 2지망 나오게 최종 정렬, 이름순 정렬
+                order = sorted(first_preference_order, key=lambda x: (x.first_preference != first_preference))
+
+            else: # 1지망만 선택할 때
+                order = sorted(order, key=lambda x: (x.first_preference == first_preference), reverse=True) # 최신순
+
+        elif order_name: # 이름순을 선택할 때
+            # name = True 로 설정하면 이름순
+            order = order.order_by('name')
+
+        else:
+            # first_preference와 name 설정 안 하면 전체를 최신순으로 정렬
+            order = order.order_by('-id')
+
+        serializer = self.get_serializer(order, many=True)
+
         return Response({
             'status': 'Success',
-            'data': response.data,
+            'data': serializer.data,
         }, status=status.HTTP_200_OK)
-    
-# detail 볼 수 있게
-class ApplicationRetrieveDetailView(viewsets.ModelViewSet):
-    """
-        해당 id값에 따른 모든 세부 정보(detail) 보이기
-    """
-    queryset = ApplyForm.objects.all().order_by('id')
-    serializer_class = ApplyFormDetailSerializer # ApplyFormDetailSerializer('__all__)'에서 가져옴
-    permission_classes = [IsAuthenticated]
-    pagination_class = ApplicationsPagination
-
-    @swagger_auto_schema(
-        operation_id='지원서 id값에 따른 디테일 모두 가져오기',
-        operation_description='''
-            id값에 해당하는 지원서의 모든 내용을 보여줍니다.<br/>
-        ''',
-        responses={
-            "200": openapi.Response(
-                description="OK",
-                examples={
-                    "application/json": {
-                        "status": "Success",
-                        "data": {"id": 1,
-                                 "created": "2023-11-15T07:14:34.728497Z",
-                                 "updated": "2023-11-15T07:14:34.728497Z",
-                                 "name": "깔루아1",
-                                 "phone_num": "010-6337-5958",
-                                 "birthdate": "2002-05-31",
-                                 "gender": "남성",
-                                 "address": "마포구",
-                                 "first_preference": "기타",
-                                 "second_preference": "신디",
-                                 "play_instrument": "기타",
-                                 "motive": "깔루아 들어가고 싶어요",
-                                }
-                    }
-                }
-            ),
-            "400": openapi.Response(
-                description="Bad Request",
-            ),
-        }
-    )
-
-    def applydetail(self, request):
-        try:
-            id = request.GET['id'] # 프론트에서 받아옴
-            detail_application = get_object_or_404(ApplyForm.objects.all(), id=id)
-            serializer = ApplyFormDetailSerializer(detail_application)
-
-            return Response({
-                'status': 'Success',
-                'data' : serializer.data,
-            }, status=status.HTTP_200_OK) 
-        
-        except ValueError as ve:
-            return Response({
-                'status': 'Error',
-                'error_message': str(ve),
-            }, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
지원서 어드민 페이지 정렬
전체 - 최신순(default) / 이름순(name=True)
세션별(ex. first_preference=보컬) - 최신순(default) / 이름순(name=True)

세션별 정렬은 1지망이 해당 세션인 지원서가 먼저 뜬 후 2지망이 해당 세션인 지원서가 뜹니다.